### PR TITLE
fix(#10): 修复 Set High/Low 重复添加后缀的问题

### DIFF
--- a/utils/misc_utils.py
+++ b/utils/misc_utils.py
@@ -68,8 +68,10 @@ def clean_collection_name(collection_name: str) -> str:
     Returns:
         清理后的名称
     """
-    # 移除常见后缀
-    suffixes = ["_low", "_high", "_LOD0", "_LOD1", "_LOD2"]
+    from ..const import LOW_SUFFIX, HIGH_SUFFIX, LOWB_SUFFIX, HIGHB_SUFFIX
+    
+    # 移除常见后缀（复用 const.py 中定义的常量）
+    suffixes = [LOW_SUFFIX, HIGH_SUFFIX, LOWB_SUFFIX, HIGHB_SUFFIX, "_LOD0", "_LOD1", "_LOD2"]
     result = collection_name
     
     for suffix in suffixes:


### PR DESCRIPTION
Closes #10

## 变更内容
- 修复 \clean_collection_name\ 函数后缀列表未包含大写后缀 (\_Low\, \_High\) 的问题
- 复用 \const.py\ 中定义的常量，符合 DRY 原则